### PR TITLE
fix: to install deno from zipped binary without using official installer

### DIFF
--- a/.github/workflows/leetcode.yml
+++ b/.github/workflows/leetcode.yml
@@ -11,10 +11,13 @@ jobs:
     runs-on: ubuntu-latest
     env:
       DENO_INSTALL: ~/.local
+      DENO_VERSION: v0.40.0
     steps:
       - uses: actions/checkout@v2
-      - run: curl -fsSL https://deno.land/x/install/install.sh | sh
-      - run: deno --version
+      - run: curl -LO https://github.com/denoland/deno/releases/download/$DENO_VERSION/deno-x86_64-unknown-linux-gnu.zip
+      - run: unzip deno-x86_64-unknown-linux-gnu.zip
+      - run: mkdir -p $DENO_INSTALL/bin && mv deno $_
+      - run: $DENO_INSTALL/bin/deno --version
       - run: $DENO_INSTALL/bin/deno test --allow-net --allow-env --allow-write leetcode/solutions/*
 
   test-go:


### PR DESCRIPTION
As official installer exits with error code 9 because it does not place deno.zip properly.